### PR TITLE
suppress warnings 

### DIFF
--- a/SPECS/edge-squid.spec
+++ b/SPECS/edge-squid.spec
@@ -107,8 +107,8 @@ lookup program (dnsserver), a program for retrieving FTP data
 autoconf
 
 # libtool fails somewhat on -fpie. PIC also works for -pie
-CXXFLAGS="$RPM_OPT_FLAGS -fPIC"
-CFLAGS="$RPM_OPT_FLAGS -fPIC"
+CXXFLAGS="$RPM_OPT_FLAGS -fPIC -Wno-error"
+CFLAGS="$RPM_OPT_FLAGS -fPIC -Wno-error"
 LDFLAGS="$RPM_LD_FLAGS -pie -Wl,-z,relro -Wl,-z,now -Wl,--warn-shared-textrel"
 
 # NIS helper has been removed because of the following bug


### PR DESCRIPTION
Found a similar failure online 

https://www.mail-archive.com/squid-users@lists.squid-cache.org/msg25026.html

Right now warnings are being treated as error, this flag will be ignoring the warnings